### PR TITLE
Add autorunner mini game

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ Anyone who wishes to learn how to create a pull request for a project on GitHub 
 
 The entire project is automated and is largely maintained by a set of bots that will verify any pixel contributions. However, if you'd like to know more about the project or submit other contributions to the project that are not a pixel, feel free to create a [GitHub issue](https://github.com/twilio-labs/open-pixel-art/issues) inside the [Open Pixel Art project](https://github.com/twilio-labs/open-pixel-art).
 
+## Playing the Game
+
+To try the autorunner locally, run:
+
+```bash
+npm start
+```
+
+and open [http://localhost:8080/game](http://localhost:8080/game) in your browser.
+
 ## Contributing
 
 In order to contribute a pixel to the canvas, you'll have to create a [pull request](https://opensource.guide/how-to-contribute/#opening-a-pull-request) to the [Open Pixel Art project on GitHub](https://github.com/twilio-labs/open-pixel-art).

--- a/assets/autorunner/autorunner.js
+++ b/assets/autorunner/autorunner.js
@@ -1,0 +1,130 @@
+const canvas = document.getElementById('gameCanvas');
+const ctx = canvas.getContext('2d');
+canvas.width = 800;
+canvas.height = 200;
+
+const ground = canvas.height - 20;
+const player = { x: 50, y: ground - 20, w: 20, h: 20, vy: 0 };
+const gravity = 0.5;
+const jump = 8;
+const speed = 2;
+
+let level = 1;
+const maxLevel = 10;
+let lives = 5;
+let timeLeft = 120;
+let obstacles = [];
+let lastTime = null;
+let distSinceLast = 0;
+let nextGap = gap();
+let playing = true;
+
+function gap() {
+  return 20 + Math.random() * 10;
+}
+
+function updateHud() {
+  document.getElementById('level').textContent = level;
+  document.getElementById('time').textContent = Math.ceil(timeLeft);
+  document.getElementById('lives').textContent = lives;
+}
+
+function resetLevel() {
+  player.y = ground - player.h;
+  player.vy = 0;
+  obstacles = [];
+  distSinceLast = 0;
+  nextGap = gap();
+  timeLeft = 120;
+  updateHud();
+}
+
+function nextLevel() {
+  if (level >= maxLevel) {
+    playing = false;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.font = '24px sans-serif';
+    ctx.fillText('Victoire !', canvas.width / 2 - 60, canvas.height / 2);
+    return;
+  }
+  level++;
+  resetLevel();
+}
+
+function loseLife() {
+  lives--;
+  if (lives <= 0) {
+    playing = false;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.font = '24px sans-serif';
+    ctx.fillText('Game Over', canvas.width / 2 - 70, canvas.height / 2);
+    return;
+  }
+  resetLevel();
+}
+
+document.addEventListener('keydown', (e) => {
+  if (e.code === 'Space' && player.y >= ground - player.h) {
+    player.vy = -jump;
+  }
+});
+
+function update(dt) {
+  player.vy += gravity;
+  player.y += player.vy;
+  if (player.y > ground - player.h) {
+    player.y = ground - player.h;
+    player.vy = 0;
+  }
+
+  obstacles.forEach((o) => {
+    o.x -= speed;
+  });
+  obstacles = obstacles.filter((o) => o.x + o.w > 0);
+
+  distSinceLast += speed;
+  if (distSinceLast >= nextGap) {
+    obstacles.push({ x: canvas.width, y: ground - 20, w: 20, h: 20 });
+    distSinceLast = 0;
+    nextGap = gap();
+  }
+
+  obstacles.forEach((o) => {
+    if (
+      player.x < o.x + o.w &&
+      player.x + player.w > o.x &&
+      player.y + player.h > o.y
+    ) {
+      loseLife();
+    }
+  });
+
+  timeLeft -= dt / 1000;
+  if (timeLeft <= 0) {
+    nextLevel();
+  }
+  updateHud();
+}
+
+function draw() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.fillStyle = 'red';
+  ctx.fillRect(player.x, player.y, player.w, player.h);
+  ctx.fillStyle = '#333';
+  obstacles.forEach((o) => {
+    ctx.fillRect(o.x, o.y, o.w, o.h);
+  });
+}
+
+function loop(timestamp) {
+  if (!playing) return;
+  if (!lastTime) lastTime = timestamp;
+  const dt = timestamp - lastTime;
+  lastTime = timestamp;
+  update(dt);
+  draw();
+  requestAnimationFrame(loop);
+}
+
+resetLevel();
+requestAnimationFrame(loop);

--- a/game.njk
+++ b/game.njk
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Autorunner</title>
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans|Press+Start+2P&display=swap" rel="stylesheet" />
+    <link href="/assets/nes.css/nes.min.css" rel="stylesheet" />
+    <link rel="stylesheet" href="/styles/main.css" />
+  </head>
+  <body>
+    <header class="text-center">
+      <h1>Autorunner</h1>
+      <nav>
+        <a class="nes-btn" href="/">Home</a>
+      </nav>
+    </header>
+    <main class="text-center">
+      <p>Level: <span id="level">1</span> | Time: <span id="time">120</span> | Lives: <span id="lives">5</span></p>
+      <canvas id="gameCanvas" class="nes-container is-rounded"></canvas>
+    </main>
+    <script src="/assets/autorunner/autorunner.js"></script>
+  </body>
+</html>

--- a/index.njk
+++ b/index.njk
@@ -43,6 +43,9 @@
           </li>
           <li class="nav-item">
             <a class="nes-btn" href="#contributors">See All Contributors</a>
+            </li>
+          <li class="nav-item">
+            <a class="nes-btn" href="/game/">Play Game</a>
           </li>
           <li class="nav-item">
             <a class="nes-btn external-link" href="https://github.com/twilio-labs/open-pixel-art" target="_blank" rel="noreferrer" aria-label="Check on Github">View on GitHub</a>


### PR DESCRIPTION
## Summary
- create simple autorunner game script
- add `/game` page to host the canvas
- link to the game from the home page
- document how to start the game

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68741997471c83338353dfdd86e3a5db